### PR TITLE
fix(app): show persistent, readable error when site creation fails

### DIFF
--- a/app/src/i18n/en/add-site.json
+++ b/app/src/i18n/en/add-site.json
@@ -31,7 +31,7 @@
     "back": "Back",
     "create_site": "Create Site",
     "limit_reached": "Limit Reached",
-    "private_site_limit_reached": "Private site limit reached",
+    "private_site_limit_reached": "Private site limit reached. Upgrade your plan to create more private sites.",
     "project_created_success": "Project created successfully",
     "something_went_wrong": "Something went wrong!"
   }

--- a/app/src/layouts/components/add-site.tsx
+++ b/app/src/layouts/components/add-site.tsx
@@ -39,6 +39,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { UpgradeCta } from "@/components/upgrade-cta";
 import { UpgradeDialog } from "@/components/upgrade-dialog";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useDialog } from "@/hooks/use-dialog";
@@ -51,13 +52,13 @@ import { cn } from "@/lib/utils/cn";
 import { isDemoUrl } from "@/lib/utils/demo-urls";
 import { IS_DEMO } from "@/lib/constant";
 import { errorMessage } from "@/lib/utils/error";
+import { isSiteCreationPlanLimitError } from "@/lib/utils/site-creation-error";
 import {
   isGitHubProvider,
   isGitLabProvider,
   TGitProvider,
 } from "@/lib/utils/provider-checker";
 import { projectSchema } from "@/lib/validate";
-import { AxiosBaseQueryError } from "@/redux/features/api-slice";
 import { useGetGitHubBranchesQuery as useGitHubBranches } from "@/redux/features/github";
 import { useGetGitLabBranchesQuery } from "@/redux/features/gitlab/gitlab-api";
 import { useGetOrgQuery, useGetOrgsQuery } from "@/redux/features/orgs/org-api";
@@ -148,6 +149,7 @@ export default function AddSite({
   const [showAddOrg, setShowAddOrg] = useState(false);
   const [showUpgradeOrg, setShowUpgradeOrg] = useState(false);
   const [repoOpen, setRepoOpen] = useState(false);
+  const [creationError, setCreationError] = useState<string | null>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const projectForm = useForm<z.infer<typeof projectSchema>>({
     resolver: zodResolver(projectSchema),
@@ -230,8 +232,7 @@ export default function AddSite({
     );
   }, [branches, projectForm]);
 
-  const [addProject, { isLoading: isProjectAdding, error, isError }] =
-    useAddProjectMutation();
+  const [addProject, { isLoading: isProjectAdding }] = useAddProjectMutation();
 
   const [step, setStep] = useState<"selection" | "form">("selection");
 
@@ -239,6 +240,7 @@ export default function AddSite({
   useEffect(() => {
     if (!isOpen) {
       setStep("selection");
+      setCreationError(null);
       projectForm.reset();
     }
   }, [isOpen, projectForm]);
@@ -458,6 +460,7 @@ export default function AddSite({
               onSubmit={projectForm.handleSubmit(async (data) => {
                 try {
                   if (!orgId) return;
+                  setCreationError(null);
                   if (data.visibility === "private") {
                     if (!org) return;
                     const ownerArray = org.ownerData || [];
@@ -473,7 +476,7 @@ export default function AddSite({
                       privateCount >=
                       getPlanLimits(active_package).org_private_site_limit
                     ) {
-                      toast.error(tAddSite("private_site_limit_reached"));
+                      setCreationError(tAddSite("private_site_limit_reached"));
                       return;
                     }
                   }
@@ -489,7 +492,7 @@ export default function AddSite({
                   toast.success(tAddSite("project_created_success"));
                   router.push(`/org-${org_id}/${project_id}`);
                 } catch (error) {
-                  toast.error(
+                  setCreationError(
                     errorMessage(error) || tAddSite("something_went_wrong"),
                   );
                 }
@@ -771,11 +774,16 @@ export default function AddSite({
               </FieldGroup>
 
               <FormError
-                message={(error as AxiosBaseQueryError)?.data.message}
-                isError={isError}
-                error={(error as AxiosBaseQueryError)?.data?.errorMessage ?? []}
-                data={null}
+                message={creationError ?? undefined}
+                isError={Boolean(creationError)}
+                error={null}
+                onReset={() => setCreationError(null)}
               />
+              {creationError && isSiteCreationPlanLimitError(creationError) && (
+                <div className="mt-2">
+                  <UpgradeCta labelKey="private_sites" size="sm" />
+                </div>
+              )}
             </form>
           )}
 

--- a/app/src/layouts/components/form-error.tsx
+++ b/app/src/layouts/components/form-error.tsx
@@ -21,9 +21,9 @@ export default function FormError({
   onReset,
 }: FormErrorProps) {
   const derivedErrors = useMemo<TError[]>(() => {
-    if (Array.isArray(errors)) return errors;
+    if (Array.isArray(errors) && errors.length > 0) return errors;
 
-    if (errors && typeof errors === "object") {
+    if (errors && typeof errors === "object" && !Array.isArray(errors)) {
       const err = errors as BetterFetchError;
       return [
         {
@@ -61,7 +61,7 @@ export default function FormError({
           className="relative flex items-center space-x-2 text-sm font-semibold"
         >
           <TriangleAlert />
-          <span className="flex-1">{err.message}</span>
+          <span className="flex-1 text-pretty break-words">{err.message}</span>
           <div>
             <Button
               type="button"

--- a/app/src/lib/utils/site-creation-error.test.ts
+++ b/app/src/lib/utils/site-creation-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isSiteCreationPlanLimitError } from "./site-creation-error";
+
+describe("isSiteCreationPlanLimitError", () => {
+  it("matches the client and API private-limit copy", () => {
+    expect(isSiteCreationPlanLimitError("Private site limit reached")).toBe(
+      true,
+    );
+    expect(
+      isSiteCreationPlanLimitError(
+        "You have reached the maximum number of active private projects (1) for your current plan.",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches total site plan limits", () => {
+    expect(
+      isSiteCreationPlanLimitError(
+        "You have reached the maximum number of active projects (3) for your current plan.",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated failures", () => {
+    expect(isSiteCreationPlanLimitError("Something went wrong!")).toBe(false);
+    expect(isSiteCreationPlanLimitError("Repository not found")).toBe(false);
+  });
+});

--- a/app/src/lib/utils/site-creation-error.ts
+++ b/app/src/lib/utils/site-creation-error.ts
@@ -1,0 +1,6 @@
+/** True when a site-creation failure is a plan / quota business rule. */
+export function isSiteCreationPlanLimitError(message: string): boolean {
+  return /private site limit|maximum number of active private|maximum number of active projects|quota limit/i.test(
+    message,
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Makes site-creation failures readable and persistent. Previously, a plan-limit failure (e.g. creating a private site past the plan's limit) fired a bottom-corner toast that auto-dismissed and truncated its message — the user couldn't tell why creation failed. Now:

- Plan-limit and other creation failures render as a dismissible inline `FormError` in the Create Site modal (full message, wraps properly, cleared on close/resubmit) instead of an ephemeral toast.
- Plan-limit failures also surface the Upgrade CTA (`private_sites` label — cloud billing link; no-op in OSS).
- `FormError` no longer treats an empty `errorMessage: []` as a message, and long messages wrap (`text-pretty break-words`) instead of truncating — this fixes readability for all form errors, not just this modal.
- EN copy for `private_site_limit_reached` clarified; unit tests added for the new `isSiteCreationPlanLimitError` helper.

Found as a trial user hitting the private-site limit — related report in your support inbox from michael@brightsite.com.au.

Two notes for reviewers:
- Only the EN locale string was extended — happy to propagate the upgrade hint to the other locales if wanted.
- `isSiteCreationPlanLimitError` matches on message copy since the API doesn't expose an error code for this case — a deliberate light-touch trade-off. If you'd prefer a code-based check, point me at the field and I'll rework it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Code typechecks (`pnpm build:api` and `tsc --noEmit` in app)
- [x] Formatted with Prettier
- [x] Tested locally (`pnpm test` — 524 app + 115 api passing, incl. new `site-creation-error.test.ts`)